### PR TITLE
Make position \!important to prevent iframe being pushed to bottom of page

### DIFF
--- a/buffer-overlay.js
+++ b/buffer-overlay.js
@@ -149,7 +149,7 @@ var bufferData = function (port, postData) {
     config.overlay = {
         endpoint: (config.local ? 'http:' : document.location.protocol) + '//bufferapp.com/add/',
         localendpoint: (config.local ? 'http:' : document.location.protocol) + '//local.bufferapp.com/add/',
-        getCSS: function () { return "border:none;height:100%;width:100%;position:fixed;z-index:99999999;top:0;left:0;display:block !important;"; }
+        getCSS: function () { return "border:none;height:100%;width:100%;position:fixed !important;z-index:99999999;top:0;left:0;display:block !important;"; }
     };
 
     // Method for handling the async firing of the cb


### PR DESCRIPTION
Trello task: https://trello.com/c/xBWnrP40

Stops the Buffer popup popping-up at the bottom of the page if iframe style is relative.
