### PR TITLE
Fix image scraper

### DIFF
--- a/embeds/buffer-scraper.js
+++ b/embeds/buffer-scraper.js
@@ -93,7 +93,7 @@
         var ogtmp;
         if( ogimage.length > 0 ) {
             ogtmp = $('<img>').prop({
-                'src': $(ogimage).text(),
+                'src': $(ogimage).attr('content'),
                 'class': 'opengraph',
                 'width': 1000, // High priority
                 'height': 1000


### PR DESCRIPTION
For some pages instead of image URL, the actual URL of page was getting picked up

URL: On https://code.facebook.com/posts/454616284650560/building-a-faster-messenger/ 
Browser: Firefox 30.0a2