### PR TITLE
Buffer button does not seem to work when triggering it from the "Pin It" extension

### DIFF
--- a/embeds/buffer-pinterest.js
+++ b/embeds/buffer-pinterest.js
@@ -142,6 +142,9 @@
       },
       getData: function(el) {
         var $img = $(el).parents('.boardsWrapper').siblings('.pinContainer').find('.pinImg');
+        if (!$img) { // Default to grab .pinImg from a top-down approach rather than navigating from $(el) if that does not find it
+          $img = $('.pinImg');
+        }
 
         var image = $img.attr('src');
         // Grab text from image alt attribute

--- a/embeds/buffer-pinterest.js
+++ b/embeds/buffer-pinterest.js
@@ -142,7 +142,7 @@
       },
       getData: function(el) {
         var $img = $(el).parents('.boardsWrapper').siblings('.pinContainer').find('.pinImg');
-        if (!$img) { // Default to grab .pinImg from a top-down approach rather than navigating from $(el) if that does not find it
+        if ($img.length == 0) { // Default to grab .pinImg from a top-down approach rather than navigating from $(el) if that does not find it
           $img = $('.pinImg');
         }
 


### PR DESCRIPTION
Hey @pioul! Would love your :eyes: and thoughts on this one :smile: It
looks like it might fix bufferapp/buffer-web#8353

Sometimes, the `$img` element is not being found traversing the tree as we
are doing. The only fix I could think of was to default to grab the
`$('.pinImg')` directly on cases it was undefined with the other way. Not
sure if it fixes things, and my extension-fu is a bit rusty anyway haha
:sweat_smile:

Thanks so much for taking a look!