### PR TITLE
Change "url" function to avoid anchor links

### DIFF
--- a/buffer-overlay.js
+++ b/buffer-overlay.js
@@ -281,7 +281,7 @@ var getOverlayConfig = function(postData){
           cb(link);
         }
         else{
-          cb(window.location.href);
+          cb(window.location.href.split('#')[0]);
         }
       },
       encode: function (val) {


### PR DESCRIPTION
Hi Buffer Team,

This is just a quick update/suggestion that could help publishers to share the correct link, removing possibles anchors from the URL.
The function is the same as "window.location.href", but will stripe all the anchor tags ("example.com/page.html#anchor" is converted to "example.com/page.html" )

This way is removed any anchor text from the link, that could have impact in the sharing (for instance, on Facebook Pages with Instant articles, where a link with and without anchor text is marked as "different") or that can lead the users to "jump" in the page without being that what the publisher wants...
If needed, the link with anchor tags can still be shared manually by the user in the text area (this is just related with the "auto fetch" of the page link). Google Analytics tags are also not affected in any way for what i can see...

Probably there is other ways of do this. But this is the easy one and, probably, the one more "compatibility safe".

Keep going with the great work!
